### PR TITLE
Attach buttons to the related textarea/code block

### DIFF
--- a/sources/main.js
+++ b/sources/main.js
@@ -315,35 +315,6 @@ const App = () => {
             <div class="col">
               <button
                 class="btn btn-primary"
-                id="copy"
-                onclick=${() => {
-                  navigator.clipboard.writeText(r.ast);
-                  if (window.getSelection) {
-                    const selection = window.getSelection();
-                    const range = document.createRange();
-                    range.selectNodeContents(
-                      document.getElementById("output_scala"),
-                    );
-                    selection.removeAllRanges();
-                    selection.addRange(range);
-                  }
-                }}
-              >
-                copy
-              </button>
-            </div>
-            <div class="col">
-              <button
-                class="btn btn-primary"
-                onclick=${() => formatInput()}
-                id="format_input"
-              >
-                format input scala code
-              </button>
-            </div>
-            <div class="col">
-              <button
-                class="btn btn-primary"
                 id="clear_local_storage"
                 onclick=${() => localStorage.clear()}
               >
@@ -527,6 +498,14 @@ const App = () => {
     </details>
     <div class="row">
       <div class="col">
+        <button
+          class="btn btn-secondary"
+          style="border-bottom-left-radius: 0; border-bottom-right-radius: 0;"
+          onclick=${() => formatInput()}
+          id="format_input"
+        >
+          format input scala code
+        </button>
         <textarea
           style="width: 100%; height: 800px"
           id="input_scala"
@@ -536,6 +515,23 @@ const App = () => {
         ></textarea>
       </div>
       <div class="col">
+        <button
+          class="btn btn-secondary"
+          style="border-bottom-left-radius: 0; border-bottom-right-radius: 0;"
+          id="copy"
+          onclick=${() => {
+            navigator.clipboard.writeText(r.ast);
+            if (window.getSelection) {
+              const selection = window.getSelection();
+              const range = document.createRange();
+              range.selectNodeContents(document.getElementById("output_scala"));
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
+          }}
+        >
+          copy
+        </button>
         <pre>
         <code
           id="output_scala"


### PR DESCRIPTION
## Before
- Two buttons are placed in the reverse order of the related text-area and code-block

<img width="1512" alt="image" src="https://github.com/xuwei-k/scalameta-ast/assets/127635/3f2c0d29-2966-4545-b67a-fe68dc3591b2">


## After

- Two buttons are attached to the relevant element, so each role is clearer.
- Buttons are always visible (not hidden in header). Because I think we use them more often than header
- Background color is changed to `secondary` to make them low-profile

<img width="1512" alt="image" src="https://github.com/xuwei-k/scalameta-ast/assets/127635/3e941518-b5d8-4c2a-91ef-ff206db197fa">

<img width="1509" alt="image" src="https://github.com/xuwei-k/scalameta-ast/assets/127635/7be095f0-cdbb-4e0f-8505-e630b7e4b2a0">
